### PR TITLE
fix: close file before exiting early from io.lines() loop

### DIFF
--- a/lua/telescope/_extensions/lazy_plugins/finder.lua
+++ b/lua/telescope/_extensions/lazy_plugins/finder.lua
@@ -41,10 +41,13 @@ function M.line_number_search(repo_name, filepath)
   local from_line = M.get_last_search_history(repo_name, filepath) or 1
   local current_line = 1
 
-  for line_str in io.lines(filepath) do
+  local file, err = io.open(filepath)
+  assert(file, err)
+  for line_str in file:lines() do
     if current_line >= from_line then
       if find(line_str, dq_search, 1, true) or find(line_str, sq_search, 1, true) then
         M.add_search_history(repo_name, filepath, current_line + 1)
+        file:close()
         return current_line, true
       end
     end


### PR DESCRIPTION
tldr; avoid leaking file descriptors (fd) too quickly, which may cause error out from reaching upper fd limit.

I use a neovim config that consists of a large/sizable number of plugins. This is largely due to the fact that I use a neovim "distro", astronvim. Since I enjoy using the defaults astronvim provides alongside some tweaks of my own, this results in a decent number of lazy spec files that need to be opened — my own personal additions/tweaks in `~/.config/nvim/`, and the "defaults" provided by astronvim under `~/.local/share/nvim/lazy/`. 

I don't know generally for all shells, but for at least zsh (the shell I use) the default resource limit for the number of open file descriptors is 256 (i.e., if a shell and its processes reach that open file descriptor limit, any additional file open attempts will fail). The number of file descriptors created by running `require("telescope").extensions.lazy_plugins.lazy_plugins()` — in addition to the number of already active file descriptors of my running nvim instance — will push past that 256 limit (which I have a preference to leave as is). 

The UI behavior I was observing was that upon executing `require("telescope").extensions.lazy_plugins.lazy_plugins()` nvim would display errors that too many files had been opened. The stack trace pointed me to the for loop that I modified in my commit. The iterator function returned by `io.lines()` automatically closes the specified file, but only after it has iterated over every line in the file and returns nil. If the repo name is successfully found within the file it leaves the for loop (via the return) before it has a chance to reach the last line of the file and automatically close it. This is technically fine since eventually lua's garbage collector will close the file(s) for you, however before that has a chance to happen, repeated visits to `M.line_number_search()` can push the number of open file descriptors past the limit — and it does in my case with the number of lazy spec files I have. 

All I did was swap out the nice shorter form `io.lines()` with a `io.open()` and `file:lines()` so that I could have a file handle to use for a manual `file:close()` before returning from `M.line_number_search()`. 

Thanks for your consideration :)